### PR TITLE
fix pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [ main, master ]
     tags:
       - "v*"
 


### PR DESCRIPTION
This pull request makes a small update to the CI workflow configuration by allowing the workflow to run on pushes to both the `main` and `master` branches, instead of only `main`.