### PR TITLE
fix code smells

### DIFF
--- a/src/AdaskoTheBeAsT.AutoMapper.SimpleInjector/AutoMapperSimpleInjectorConfiguration.cs
+++ b/src/AdaskoTheBeAsT.AutoMapper.SimpleInjector/AutoMapperSimpleInjectorConfiguration.cs
@@ -159,7 +159,7 @@ public class AutoMapperSimpleInjectorConfiguration
     public AutoMapperSimpleInjectorConfiguration WithMapperAssemblyMarkerTypes(params Type[] mapperAssemblyMarkerTypes)
     {
         ArgumentNullException.ThrowIfNull(mapperAssemblyMarkerTypes);
-        AssembliesToScan = mapperAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly).ToArray();
+        AssembliesToScan = [.. mapperAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly)];
         return this;
     }
 
@@ -175,7 +175,7 @@ public class AutoMapperSimpleInjectorConfiguration
     public AutoMapperSimpleInjectorConfiguration WithMapperAssemblyMarkerTypes(IEnumerable<Type> mapperAssemblyMarkerTypes)
     {
         ArgumentNullException.ThrowIfNull(mapperAssemblyMarkerTypes);
-        AssembliesToScan = mapperAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly).ToArray();
+        AssembliesToScan = [.. mapperAssemblyMarkerTypes.Select(t => t.GetTypeInfo().Assembly)];
         return this;
     }
 

--- a/test/unit/AdaskoTheBeAsT.AutoMapper.SimpleInjector.Test/AutoMapperSimpleInjectorConfigurationTests.cs
+++ b/test/unit/AdaskoTheBeAsT.AutoMapper.SimpleInjector.Test/AutoMapperSimpleInjectorConfigurationTests.cs
@@ -14,7 +14,7 @@ public class AutoMapperSimpleInjectorConfigurationTests
     [Fact]
     public void DefaultLicenseKey_ShouldBeNull()
     {
-        // Arrange & Act
+        // Arrange and Act
         var config = new AutoMapperSimpleInjectorConfiguration();
 
         // Assert

--- a/test/unit/AdaskoTheBeAsT.AutoMapper.SimpleInjector.Test/Profiles/Profile2.cs
+++ b/test/unit/AdaskoTheBeAsT.AutoMapper.SimpleInjector.Test/Profiles/Profile2.cs
@@ -2,6 +2,7 @@ using AutoMapper;
 
 namespace AdaskoTheBeAsT.AutoMapper.SimpleInjector.Test.Profiles;
 
+#pragma warning disable MA0182
 internal sealed class Profile2 : Profile
 {
     public Profile2()
@@ -11,3 +12,4 @@ internal sealed class Profile2 : Profile
             .ForMember(d => d.ConvertedValue, opt => opt.ConvertUsing<DependencyValueConverter, int>());
     }
 }
+#pragma warning restore MA0182


### PR DESCRIPTION
This pull request introduces minor improvements to the test codebase, focusing on code clarity and static analysis compliance. The main changes include the addition of pragma directives to suppress and restore a specific analyzer warning in `Profile2.cs`, and a small comment update in a test method.

Code quality and static analysis:

* Added `#pragma warning disable MA0182` and `#pragma warning restore MA0182` around the `Profile2` class to suppress and then re-enable the MA0182 analyzer warning. (`test/unit/AdaskoTheBeAsT.AutoMapper.SimpleInjector.Test/Profiles/Profile2.cs`) [[1]](diffhunk://#diff-dcc9f584ff0a4e19dfc1d967e0396fba26e00ef096921f7184168bcaa55005f3R5) [[2]](diffhunk://#diff-dcc9f584ff0a4e19dfc1d967e0396fba26e00ef096921f7184168bcaa55005f3R15)

Code clarity:

* Updated a comment in the `DefaultLicenseKey_ShouldBeNull` test method for clarity. (`test/unit/AdaskoTheBeAsT.AutoMapper.SimpleInjector.Test/AutoMapperSimpleInjectorConfigurationTests.cs`)