### PR TITLE
update SonarAnalyzer.CSharp

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
     <PackageReference Include="Roslynator.Analyzers" Version="4.15.0" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.15.0" PrivateAssets="all" ExcludeAssets="runtime" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.24.0.138807" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.25.0.139117" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all" ExcludeAssets="runtime" />
 
     <!-- Common StyleCop configuration -->


### PR DESCRIPTION
This pull request includes a minor update to the code analysis tooling. The only change is an upgrade of the `SonarAnalyzer.CSharp` NuGet package to a newer version.

- Upgraded the `SonarAnalyzer.CSharp` package from version 10.24.0.138807 to 10.25.0.139117 in `Directory.Build.props` to ensure the latest static analysis checks are available.